### PR TITLE
Add multi-tenant capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ s2 = Sequenced.create
 s2.sequence #=> 2 # and so on
 ```
 
+It is possible to add an additional discriminator to the sequence (e.g. a tenant id)
+```ruby
+class Sequenced
+	include Mongoid::Document
+	include Mongoid::Sequence
+
+  field :my_sequence, :type => Integer
+  belongs_to :organization
+
+	sequence :my_sequence, :organization_id
+end
+```
+
 It's also possible to make the `id` field behave like this:
 
 ```ruby

--- a/lib/mongoid-sequence.rb
+++ b/lib/mongoid-sequence.rb
@@ -20,16 +20,13 @@ module Mongoid
     end
 
     def set_sequence
-      sequences = Mongoid.default_session[:'__sequences']
-      prefix = ''
-      prefix = self.send(self.class.sequence_prefix).to_s if self.class.sequence_prefix.present?
+      sequences = self.mongo_session['__sequences']
+      prefix    = self.class.sequence_prefix.present? ? self.send(self.class.sequence_prefix).to_s : ''
       self.class.sequence_fields.each do |field|
-        next_sequence = sequences.find_and_modify(:query  => {"_id" => "#{self.class.name.underscore}_#{prefix}_#{field}"},
-                                                  :update => {"$inc" => {"seq" => 1}},
-                                                  :new    => true,
-                                                  :upsert => true)
-
-        self[field] = next_sequence["seq"]
+        next_sequence = sequences.where(_id: "#{self.class.name.underscore}_#{prefix}_#{field}").modify(
+            { '$inc' => { seq: 1 } }, upsert: true, new: true
+        )
+        self[field]   = next_sequence["seq"]
       end if self.class.sequence_fields
     end
   end

--- a/lib/mongoid-sequence.rb
+++ b/lib/mongoid-sequence.rb
@@ -10,18 +10,21 @@ module Mongoid
     end
 
     module ClassMethods
-      attr_accessor :sequence_fields
+      attr_accessor :sequence_fields, :sequence_prefix
 
-      def sequence(field)
+      def sequence(field, prefix = '')
         self.sequence_fields ||= []
         self.sequence_fields << field
+        self.sequence_prefix = prefix
       end
     end
 
     def set_sequence
       sequences = self.db.collection("__sequences")
+      prefix = ''
+      prefix = self.send(self.class.sequence_prefix).to_s if self.class.sequence_prefix.present?
       self.class.sequence_fields.each do |field|
-        next_sequence = sequences.find_and_modify(:query  => {"_id" => "#{self.class.name.underscore}_#{field}"},
+        next_sequence = sequences.find_and_modify(:query  => {"_id" => "#{self.class.name.underscore}_#{prefix}_#{field}"},
                                                   :update => {"$inc" => {"seq" => 1}},
                                                   :new    => true,
                                                   :upsert => true)

--- a/lib/mongoid-sequence.rb
+++ b/lib/mongoid-sequence.rb
@@ -20,7 +20,7 @@ module Mongoid
     end
 
     def set_sequence
-      sequences = Mongoid.default_session.collection("__sequences")
+      sequences = Mongoid.default_session[:'__sequences']
       prefix = ''
       prefix = self.send(self.class.sequence_prefix).to_s if self.class.sequence_prefix.present?
       self.class.sequence_fields.each do |field|

--- a/lib/mongoid-sequence.rb
+++ b/lib/mongoid-sequence.rb
@@ -20,7 +20,7 @@ module Mongoid
     end
 
     def set_sequence
-      sequences = self.db.collection("__sequences")
+      sequences = Mongoid.default_session.collection("__sequences")
       prefix = ''
       prefix = self.send(self.class.sequence_prefix).to_s if self.class.sequence_prefix.present?
       self.class.sequence_fields.each do |field|

--- a/lib/mongoid-sequence/version.rb
+++ b/lib/mongoid-sequence/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module Sequence
-    VERSION = "0.1"
+    VERSION = "0.2"
   end
 end

--- a/mongoid-sequence.gemspec
+++ b/mongoid-sequence.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Specify fields to behave like a sequence number (exactly like the "id" column in conventional SQL flavors).}
   gem.homepage      = "https://github.com/goncalossilva/mongoid-sequence"
 
+  gem.add_dependency("moped", ">= 1.0.0.rc")
   gem.add_dependency("mongoid", ">= 3.0.0.rc")
   gem.add_dependency("activesupport", "~> 3.1")
   gem.add_development_dependency("rake", "~> 0.9")

--- a/mongoid-sequence.gemspec
+++ b/mongoid-sequence.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Specify fields to behave like a sequence number (exactly like the "id" column in conventional SQL flavors).}
   gem.homepage      = "https://github.com/goncalossilva/mongoid-sequence"
 
-  gem.add_dependency("mongoid", "> 2.0")
+  gem.add_dependency("mongoid", ">= 3.0.0.rc")
   gem.add_dependency("activesupport", "~> 3.1")
   gem.add_development_dependency("rake", "~> 0.9")
 

--- a/mongoid-sequence.gemspec
+++ b/mongoid-sequence.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Specify fields to behave like a sequence number (exactly like the "id" column in conventional SQL flavors).}
   gem.homepage      = "https://github.com/goncalossilva/mongoid-sequence"
 
-  gem.add_dependency("mongoid", "~> 2.0")
+  gem.add_dependency("mongoid", "> 2.0")
   gem.add_dependency("activesupport", "~> 3.1")
   gem.add_development_dependency("rake", "~> 0.9")
 

--- a/test/consistency_test.rb
+++ b/test/consistency_test.rb
@@ -32,4 +32,13 @@ class SequenceTest < BaseTest
     assert_equal FirstSequencedModel.only(:auto_increment).map(&:auto_increment).sort, (1..n).to_a
     assert_equal SecondSequencedModel.only(:auto_increment).map(&:auto_increment).sort, (1..n).to_a
   end
+
+  def test_prefix_sequence_consistency
+    n = 100
+    n.times do
+      PrefixSequencedModel.create(tenant_id: n)
+    end
+
+    assert_equal PrefixSequencedModel.only(:auto_increment).map(&:auto_increment).sort, (1..n).to_a
+  end
 end

--- a/test/models/prefix_sequenced_model.rb
+++ b/test/models/prefix_sequenced_model.rb
@@ -1,7 +1,8 @@
-class SecondSequencedModel
+class PrefixSequencedModel
   include Mongoid::Document
   include Mongoid::Sequence
 
+  field :tenant_id, :type => Integer
   field :auto_increment, :type => Integer
-  sequence :auto_increment
+  sequence :auto_increment, :tenant_id
 end

--- a/test/models/prefix_sequenced_model.rb
+++ b/test/models/prefix_sequenced_model.rb
@@ -1,0 +1,7 @@
+class SecondSequencedModel
+  include Mongoid::Document
+  include Mongoid::Sequence
+
+  field :auto_increment, :type => Integer
+  sequence :auto_increment
+end

--- a/test/mongoid.yml
+++ b/test/mongoid.yml
@@ -1,0 +1,6 @@
+test:
+  sessions:
+    default:
+      database: mongoid_sequence_test
+      hosts:
+        - localhost:27017

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,10 +4,7 @@ require "mongoid"
 
 require File.expand_path("../../lib/mongoid-sequence", __FILE__)
 
-Mongoid.configure do |config|
-  name = "mongoid_sequence_test"
-  config.master = Mongo::Connection.new.db(name)
-end
+Mongoid.load!("#{File.dirname(__FILE__)}/mongoid.yml", "test")
 
 Dir["#{File.dirname(__FILE__)}/models/*.rb"].each { |f| require f }
 
@@ -15,6 +12,6 @@ class BaseTest < Test::Unit::TestCase
   def test_default; end # Avoid "No tests were specified." on 1.8.7
 
   def teardown
-    Mongoid.master.collections.select {|c| c.name !~ /system/ }.each(&:remove)
+    Mongoid::Sessions.default.use('mongoid_sequence_test').drop
   end
 end


### PR DESCRIPTION
Hi! 

Thanks for this nice gem. I just added a small feature that allows one to specify another model field as additional discriminator for the sequence. The value of the specified field is added to the sequence name.

I need this feature to generate different sequences for different tenants.

Maybe others might find this useful too.

Thanks for considering this addition,
Carsten
